### PR TITLE
Allows nodes to specify a custom OSC constructor

### DIFF
--- a/OSC-export.js
+++ b/OSC-export.js
@@ -180,21 +180,29 @@ OSC.export = (function () {
                         packets.add(OSC.GetCreateGroupAddr(),"ss", name, "/");
                         for (var ai = 0; ai < count; ai++)
                         {
+							var grpName = "i"+ai; // this exact name is needed if the object provides its own OSC constructor
+							
                             if (node._def.dynInputs == undefined) { //if (node._def.defaults.inputs == undefined) {
-                                packets.add(OSC.GetCreateObjectAddr(),"sss",n.type, "i"+ai, fixLeadingSlash(name));
+								if (node._def.makeConstructor == undefined)
+									packets.add(OSC.GetCreateObjectAddr(),"sss",n.type, grpName, fixLeadingSlash(name));
+								else
+									eval(node._def.makeConstructor.group);	
                             }
                             else {
                                 // AudioMixer or any object supporting dynamic count of inputs
                                 var inputCount = RED.export.links.getDynInputDynSizePortStartIndex(node, null);
                                 node.RealInputs = inputCount;
-                                packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, "i"+ai, fixLeadingSlash(name), inputCount);//RED.arduino.export.getDynamicInputCount(node, true));
+                                packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, grpName, fixLeadingSlash(name), inputCount);//RED.arduino.export.getDynamicInputCount(node, true));
                             }
                         }
                     }
                     else {
                         //console.warn("is NOT array");
                         if (node._def.dynInputs == undefined) { //if (node._def.defaults.inputs == undefined) {
-                            packets.add(OSC.GetCreateObjectAddr(),"ss", n.type, n.name);
+							if (node._def.makeConstructor == undefined)
+								packets.add(OSC.GetCreateObjectAddr(),"ss", n.type, n.name);
+							else
+								eval(node._def.makeConstructor.root);
                         }
                         else {
                             // AudioMixer or any object supporting dynamic count of inputs
@@ -213,25 +221,32 @@ OSC.export = (function () {
                         packets.add(OSC.GetCreateGroupAddr(),"ss", name, path);
                         for (var ai = 0; ai < count; ai++)
                         {
+							var grpName = "i"+ai; // this exact name is needed if the object provides its own OSC constructor
+
                             if (node._def.dynInputs == undefined) { //if (node._def.defaults.inputs == undefined) {
-                                packets.add(OSC.GetCreateObjectAddr(),"sss", n.type, "i"+ai, fixLeadingSlash(path + "/" + name));
+                                packets.add(OSC.GetCreateObjectAddr(),"sss", n.type, grpName, fixLeadingSlash(path + "/" + name));
                             }
                             else {
                                 // AudioMixer or any object supporting dynamic count of inputs
-                                packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, "i"+ai, fixLeadingSlash(path + "/" + name), RED.export.links.getDynInputDynSizePortStartIndex(node, null));//RED.arduino.export.getDynamicInputCount(node, true));
+                                packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, grpName, fixLeadingSlash(path + "/" + name), RED.export.links.getDynInputDynSizePortStartIndex(node, null));//RED.arduino.export.getDynamicInputCount(node, true));
                             }
                         }
                     }
                     else {
                         //console.warn("this happen: " + n.name);
+						var grpName = fixLeadingSlash(path); // this exact name is needed if the object provides its own OSC constructor
+						
                         if (node._def.dynInputs == undefined) { //if (node._def.defaults.inputs == undefined) {
-                            packets.add(OSC.GetCreateObjectAddr(),"sss", n.type, n.name, fixLeadingSlash(path));
+							if (node._def.makeConstructor == undefined)
+								packets.add(OSC.GetCreateObjectAddr(),"sss", n.type, n.name, grpName);
+							else
+								eval(node._def.makeConstructor.group);
                         }
                         else {
                             // AudioMixer or any object supporting dynamic count of inputs
                             var inputCount = RED.export.links.getDynInputDynSizePortStartIndex(node, null);
                             node.RealInputs = inputCount;
-                            packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, n.name, fixLeadingSlash(path), inputCount);//RED.arduino.export.getDynamicInputCount(node, true));
+                            packets.add(OSC.GetCreateObjectAddr(),"sssi", n.type, n.name, grpName, inputCount);//RED.arduino.export.getDynamicInputCount(node, true));
                         }
                     }
                 }


### PR DESCRIPTION
If a node's JSON definition contains the "makeConstructor" element, this must have expressions named "root" and "group" which contain code which creates a well-formed entry for the OSC packets array. The default would be:
  `packets.add(OSC.GetCreateObjectAddr(),"ss", n.type, n.name);`
and
  `packets.add(OSC.GetCreateObjectAddr(),"sss", n.type, n.name, grpName);`

Note that we have to assume that packets, n, grpName and so on continue to be defined as the GUI develops. An extended constructor would (for an object in the root) be something like:
   `packets.add(OSC.GetCreateObjectAddr(),"ssif", n.type, n.name, node.memtype, node.length);`
this adds an integer and a float to the OSC create object call

Here's the JSON for constructing the AudioEffectDelayExternal object
`{
    "defaults": {
        "name": {
            "type": "c_cpp_name",
            "value": "20220403T144120_253Z_b198"
        },
        "id": {
            "noEdit": ""
        },
        "comment": {},
        "color": {
            "editor": {
                "type": "color"
            },
            "value": "#E6E0F8"
        },
        "arraySize": {
            "value": 1,
            "maxval": 255,
            "minval": 1,
            "type": "int",
            "editor": {
                "label": "Array Size",
                "help": "(not in use yet, as there is a lot of dependencies on the old style)<br>selects the array size,<br>a value of 0 or 1 mean no array<br>the max value is 255"
            }
        },
        "outputs": {
            "value": "8"
        },
        "memtype": {
            "type": "int",
            "value": "3"
        },
        "length": {
            "type": "float",
            "value": "2000.0"
        }
    },
    "makeConstructor": {
        "root": "packets.add(OSC.GetCreateObjectAddr(),\"ssif\",  \"AudioEffectDelayExternal\", n.name,          node.memtype,node.length);",
        "group": "packets.add(OSC.GetCreateObjectAddr(),\"sssif\", \"AudioEffectDelayExternal\", n.name, grpName, node.memtype,node.length);"
    },
    "editor": "autogen",
    "shortName": "delayExt2",
    "editorhelp": "",
    "inputs": 1,
    "outputs": 8,
    "category": "effect",
    "color": "#d6d0e8",
    "icon": "arrow-in.png"
}`

Note that because custom nodes can't have the same name as existing ones, the makeConstructor explicitly sets the object name to AudioEffectDelayExternal, rather than n.type, because we're actually improving on an existing object that needs extra parameters.