### PR TITLE
Make boolean parameter work

### DIFF
--- a/OSC-teensy.js
+++ b/OSC-teensy.js
@@ -406,6 +406,7 @@ var OSC = (function() {
         while (1) { // this is dangerous so special care must be taken
             if (vts[vti] == "T" || vts[vti] == "F") {
                 packet.args.push({type:vts[vti++]});
+				vi++; // absorb dummy parameter
             }
             else {
                 packet.args.push({type:vts[vti++], value:vs[vi++]});

--- a/osc-browser.js
+++ b/osc-browser.js
@@ -1097,7 +1097,11 @@ var osc = osc || {};
             var arg = args[i],
                 msgArg;
 
-            if (typeof (arg) === "object" && arg.type != undefined && arg.value != undefined) {
+            if (typeof (arg) === "object" && arg.type != undefined && 
+				(arg.value != undefined
+				|| (arg.type == 'T' || arg.type == 'F'))
+				) 
+			{
                 // We've got an explicitly typed argument.
                 console.trace("osc object:" + JSON.stringify(arg));
                 msgArg = arg;


### PR DESCRIPTION
Something like `OSC.SendData(OSC.CreateMessageData(addr,'F',0));` now works as expected, rather than throwing a message like
(WARNING) @ OSC.CreatePacket() skipped following values: (because of types and values mismatch): [0]